### PR TITLE
Handled error on get and post requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ var DataDog = function(apiKey, applicationKey, opt_apiBaseUrl) {
    }
 
    this.apiBaseUrl = opt_apiBaseUrl;
-
    this.apiKey = apiKey;
    this.applicationKey = applicationKey;
+   
 };
 
 DataDog.prototype.postEvent = function(event, callback) {
@@ -20,9 +20,9 @@ DataDog.prototype.postEvent = function(event, callback) {
       },
       json: event
    },
-   callback);
+   callback).on('error', function(e) {
+    console.log(e.message);
 };
-
 
 DataDog.prototype.postSeries = function(series, callback) {
    request.post({
@@ -33,9 +33,9 @@ DataDog.prototype.postSeries = function(series, callback) {
       },
       json: series
    },
-   callback);
+   callback).on('error', function(e) {
+    console.log(e.message);
 };
-
 
 DataDog.prototype.search = function(queryString, callback) {
    request.get({
@@ -45,8 +45,8 @@ DataDog.prototype.search = function(queryString, callback) {
          application_key: this.applicationKey
       }
    },
-   callback);
+   callback).on('error', function(e) {
+    console.log(e.message);
 };
-
 
 module.exports = DataDog;


### PR DESCRIPTION
If no internet is found, the error `EADDRINFO` causes process to crash if being run from a node.js server. Added error catching so other processes don't crash.  Right now it only logs error to the console.
