### PR TITLE
Handled error on get and post requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ var DataDog = function(apiKey, applicationKey, opt_apiBaseUrl) {
    }
 
    this.apiBaseUrl = opt_apiBaseUrl;
-
    this.apiKey = apiKey;
    this.applicationKey = applicationKey;
+   
 };
 
 DataDog.prototype.postEvent = function(event, callback) {
@@ -20,9 +20,9 @@ DataDog.prototype.postEvent = function(event, callback) {
       },
       json: event
    },
-   callback);
+   callback).on('error', function(e) {
+    console.log(e.message);
 };
-
 
 DataDog.prototype.postSeries = function(series, callback) {
    request.post({
@@ -33,9 +33,9 @@ DataDog.prototype.postSeries = function(series, callback) {
       },
       json: series
    },
-   callback);
+   callback).on('error', function(e) {
+    console.log(e.message);
 };
-
 
 DataDog.prototype.search = function(queryString, callback) {
    request.get({
@@ -45,8 +45,8 @@ DataDog.prototype.search = function(queryString, callback) {
          application_key: this.applicationKey
       }
    },
-   callback);
+   callback).on('error', function(e) {
+    console.log(e.message);
 };
-
 
 module.exports = DataDog;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var DataDog = function(apiKey, applicationKey, opt_apiBaseUrl) {
    this.apiBaseUrl = opt_apiBaseUrl;
    this.apiKey = apiKey;
    this.applicationKey = applicationKey;
-   
+
 };
 
 DataDog.prototype.postEvent = function(event, callback) {
@@ -22,7 +22,7 @@ DataDog.prototype.postEvent = function(event, callback) {
    },
    callback).on('error', function(e) {
     console.log(e.message);
-};
+});
 
 DataDog.prototype.postSeries = function(series, callback) {
    request.post({
@@ -35,7 +35,7 @@ DataDog.prototype.postSeries = function(series, callback) {
    },
    callback).on('error', function(e) {
     console.log(e.message);
-};
+});
 
 DataDog.prototype.search = function(queryString, callback) {
    request.get({
@@ -47,6 +47,6 @@ DataDog.prototype.search = function(queryString, callback) {
    },
    callback).on('error', function(e) {
     console.log(e.message);
-};
+});
 
 module.exports = DataDog;


### PR DESCRIPTION
If dns couldn't be resolved, the code threw a `EADDRINFO` error which caused other processes using this code to crash. Couldn't find a way to catch this error anywhere else, hence added it here.

Added error handling, which currently only prints the error and lets the other processes run without exiting. 

Please, either review this and merge or add some error handling method. 
